### PR TITLE
Dividing by ranges only if range is greater than 0

### DIFF
--- a/gower/gower_dist.py
+++ b/gower/gower_dist.py
@@ -113,7 +113,7 @@ def gower_get(xi_cat,xi_num,xj_cat,xj_num,feature_weight_cat,
 
     # numerical columns
     abs_delta=np.absolute(xi_num-xj_num)
-    sij_num=np.divide(abs_delta, ranges_of_numeric, out=np.zeros_like(abs_delta), where=ranges_of_numeric!=0)
+    sij_num=np.divide(abs_delta, ranges_of_numeric, out=np.zeros_like(abs_delta), where=ranges_of_numeric>0)
 
     sum_num = np.multiply(feature_weight_num,sij_num).sum(axis=1)
     sums= np.add(sum_cat,sum_num)


### PR DESCRIPTION
Dividing by ranges only if range is greater than 0 as otherwise negative values are coming as output of gower distance.  Please check if this is possible to do. If this makes the distance outside its range of [0,1] then please suggest a better alternative.